### PR TITLE
Fix scrolling issue on main Issues/PR page

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -56,6 +56,7 @@
             justify-content: space-between;
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
             z-index: 100;
+            flex-shrink: 0;
         }
 
         .app-title {
@@ -165,14 +166,21 @@
             to { transform: rotate(360deg); }
         }
 
+        /* Main App Container */
+        #mainApp {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            overflow: hidden;
+        }
+
         /* Tab Bar */
         .tab-bar {
             height: 48px;
             background: white;
             display: flex;
             border-bottom: 1px solid #e0e0e0;
-            position: sticky;
-            top: 0;
+            flex-shrink: 0;
             z-index: 50;
         }
 
@@ -217,7 +225,7 @@
             overflow-x: hidden;
             padding: 16px;
             -webkit-overflow-scrolling: touch;
-            height: calc(100vh - 56px - 48px); /* Subtract app bar and tab bar heights */
+            min-height: 0; /* Important for flexbox scrolling */
         }
 
         .issue-card, .pr-card {


### PR DESCRIPTION
## Summary
- Fixed scrolling issue where the Issues/PR list couldn't scroll beyond the page header height
- Replaced fixed height calculation with proper flexbox layout properties
- Ensured the content area fills available space and scrolls correctly

## Changes Made
- Changed `.content` from using `height: calc(100vh - 56px - 48px)` to `min-height: 0` for proper flexbox scrolling
- Added `flex-shrink: 0` to app-bar and tab-bar to prevent them from shrinking
- Added proper flexbox styles to `#mainApp` container
- Removed sticky positioning from tab-bar (not needed with flex layout)

## Test Plan
- [x] Start the dev server with `npm run dev`
- [x] Navigate to the Issues or Pull Requests tab
- [x] Verify that you can scroll through the entire list of items
- [x] Test on mobile viewport sizes
- [x] Verify detail pages still work correctly

Fixes #14

🤖 Generated with [Claude Code](https://claude.ai/code)