### PR TITLE
Add comprehensive org/repo filter dropdown

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -47,16 +47,24 @@
 
         /* App Bar */
         .app-bar {
-            height: 56px;
+            height: auto;
+            min-height: 56px;
             background: #6750a4;
             color: white;
+            display: flex;
+            flex-direction: column;
+            padding: 0;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+            z-index: 100;
+            flex-shrink: 0;
+        }
+        
+        .app-bar-main {
+            height: 56px;
             display: flex;
             align-items: center;
             padding: 0 16px;
             justify-content: space-between;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-            z-index: 100;
-            flex-shrink: 0;
         }
 
         .app-title {
@@ -86,6 +94,55 @@
 
         .icon-btn:hover {
             background: rgba(255,255,255,0.1);
+        }
+        
+        /* Filter Bar */
+        .filter-bar {
+            background: rgba(255,255,255,0.1);
+            padding: 8px 16px;
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            border-top: 1px solid rgba(255,255,255,0.1);
+        }
+        
+        .filter-label {
+            font-size: 14px;
+            opacity: 0.9;
+            white-space: nowrap;
+        }
+        
+        .filter-select {
+            flex: 1;
+            padding: 8px 12px;
+            background: white;
+            color: #333;
+            border: none;
+            border-radius: 8px;
+            font-size: 14px;
+            outline: none;
+            cursor: pointer;
+            min-width: 0;
+        }
+        
+        .filter-select:focus {
+            box-shadow: 0 0 0 2px rgba(255,255,255,0.5);
+        }
+        
+        .filter-clear {
+            padding: 6px 12px;
+            background: rgba(255,255,255,0.2);
+            color: white;
+            border: 1px solid rgba(255,255,255,0.3);
+            border-radius: 6px;
+            font-size: 12px;
+            cursor: pointer;
+            white-space: nowrap;
+            transition: background 0.2s;
+        }
+        
+        .filter-clear:hover {
+            background: rgba(255,255,255,0.3);
         }
 
         /* Auth Screen */
@@ -617,14 +674,24 @@
         <div id="mainApp" style="display: none; flex: 1; flex-direction: column;">
             <!-- App Bar -->
             <div class="app-bar">
-                <div class="app-title">GitPocket</div>
-                <div class="app-actions">
-                    <button class="icon-btn" onclick="refreshData()" title="Refresh">
-                        🔄
-                    </button>
-                    <button class="icon-btn" onclick="showProfile()" title="Profile">
-                        👤
-                    </button>
+                <div class="app-bar-main">
+                    <div class="app-title">GitPocket</div>
+                    <div class="app-actions">
+                        <button class="icon-btn" onclick="refreshData()" title="Refresh">
+                            🔄
+                        </button>
+                        <button class="icon-btn" onclick="showProfile()" title="Profile">
+                            👤
+                        </button>
+                    </div>
+                </div>
+                <!-- Filter Bar -->
+                <div class="filter-bar" id="filterBar" style="display: none;">
+                    <label class="filter-label">Filter:</label>
+                    <select class="filter-select" id="filterSelect" onchange="applyFilter()">
+                        <option value="">All repositories</option>
+                    </select>
+                    <button class="filter-clear" onclick="clearFilter()">Clear</button>
                 </div>
             </div>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -2,7 +2,7 @@
 import { appState } from './state.js';
 import { authenticate, logout, checkExistingAuth } from './auth.js';
 import { loadData } from './api.js';
-import { showTab, hideDetail, addComment, showIssueDetail, showPRDetail, mergePR, closePR } from './ui.js';
+import { showTab, hideDetail, addComment, showIssueDetail, showPRDetail, mergePR, closePR, applyFilter, clearFilter } from './ui.js';
 import { registerServiceWorker, setupInstallPrompt, installApp, hideInstallPrompt } from './pwa.js';
 
 // Export functions that need to be available globally
@@ -81,6 +81,8 @@ window.mergePR = mergePR;
 window.closePR = closePR;
 window.installApp = installApp;
 window.hideInstallPrompt = hideInstallPrompt;
+window.applyFilter = applyFilter;
+window.clearFilter = clearFilter;
 
 // Initialize when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/js/state.js
+++ b/src/js/state.js
@@ -8,7 +8,9 @@ export const appState = {
     pullRequests: [],
     currentItem: null,
     comments: [],
-    currentRepo: null
+    currentRepo: null,
+    allRepositories: [],
+    currentFilter: null
 };
 
 // In-memory storage fallback


### PR DESCRIPTION
## Summary
- Implements a comprehensive filter dropdown in the app header
- Allows filtering by organization, personal repos, or specific repository
- Improves the user experience for managing issues and PRs across multiple repositories

## Changes
- **Added filter dropdown UI** in the header with organization/repository grouping
- **Enhanced API module** to fetch user organizations and all accessible repositories
- **Implemented filter logic** that dynamically filters issues and PRs based on selection
- **Added state management** for filter persistence during the session

## Features
- 🏢 Filter by organization (shows all repos from that org)
- 👤 Filter by personal repositories
- 📁 Filter by specific repository
- 🔄 Clear filter button to reset to all repositories
- 📊 Shows repository count for each organization

## Implementation Details
The filter works by:
1. Fetching all user organizations on app load
2. Fetching repositories from both personal account and organizations
3. Grouping repositories by owner/organization in the dropdown
4. Dynamically filtering the API calls when a filter is selected
5. Maintaining filter state throughout the session

## Testing
- Tested with multiple organizations and repositories
- Verified filtering works correctly for issues and PRs
- Confirmed the dropdown properly groups repositories
- Tested the clear filter functionality

Closes #16

🤖 Generated with [Claude Code](https://claude.ai/code)