### PR TITLE
Fix GitHub API 422 error by URL-encoding affiliation parameter

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -33,7 +33,7 @@ export async function fetchUserOrganizations() {
 export async function fetchAllRepositories() {
     try {
         // Get all repositories the user has access to (not just owned)
-        const userReposResponse = await githubAPI('/user/repos?per_page=100&type=all&sort=updated&affiliation=owner,collaborator,organization_member');
+        const userReposResponse = await githubAPI('/user/repos?per_page=100&type=all&sort=updated&affiliation=owner%2Ccollaborator%2Corganization_member');
         const userRepos = await userReposResponse.json();
         
         // Get organizations


### PR DESCRIPTION
## Summary
- Fixed the 422 Unprocessable Content error when calling the GitHub API `/user/repos` endpoint
- The issue was caused by the `affiliation` parameter not being properly URL-encoded

## Problem
The API call was using:
```
affiliation=owner,collaborator,organization_member
```

This caused a 422 error because the commas need to be URL-encoded when used in query parameters.

## Solution
Changed the affiliation parameter to use URL-encoded commas:
```
affiliation=owner%2Ccollaborator%2Corganization_member
```

## Testing
The fix properly encodes the parameter according to GitHub API requirements, which should resolve the 422 error.

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)